### PR TITLE
Make version match latest git tag

### DIFF
--- a/src/jesse.app.src
+++ b/src/jesse.app.src
@@ -2,7 +2,7 @@
 
 { application, jesse
 , [ {description, "jesse"}
-  , {vsn, "0.2.0"}
+  , {vsn, "0.3.1"}
   , {modules, []}
   , {registered, []}
   , {applications, [ kernel


### PR DESCRIPTION
Otherwise it is confusing for, say, rebar, when sticking to specific versions.
