### PR TITLE
Fix validate/3 typespec

### DIFF
--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -153,7 +153,7 @@ validate(Schema, Data) ->
 %% @doc Validates json `Data' against a schema with the same key as `Schema'
 %% in the internal storage, using `Options'. If the given json is valid,
 %% then it is returned to the caller, otherwise an error with an appropriate
-%% error reason is returned. If `parser_fun' option is provided, then
+%% error reason is returned. If the `parser_fun' option is provided, then
 %% `Data' is considered to be a binary string, so `parser_fun' is used
 %% to convert the binary string to a supported internal representation of json.
 %% If `parser_fun' is not provided, then `Data' is considered to already be a
@@ -184,12 +184,12 @@ validate_with_schema(Schema, Data) ->
 
 %% @doc Validates json `Data' agains the given schema `Schema', using `Options'.
 %% If the given json is valid, then it is returned to the caller, otherwise
-%% an error with an appropriate error reason is returned. If `parser_fun' option
-%% is provided, then `Data' is considered to be a binary string, so
-%% `parser_fun' is used to convert the binary string to a supported internal
-%% representation of json.
-%% If `parser_fun' is not provided, then `Data' is considered to already be a
+%% an error with an appropriate error reason is returned. If the `parser_fun'
+%% option is provided, then both `Schema' and `Data' are considered to be a
+%% binary string, so `parser_fun' is used to convert both binary strings to a
 %% supported internal representation of json.
+%% If `parser_fun' is not provided, then both `Schema' and `Data' are considered
+%% to already be a supported internal representation of json.
 -spec validate_with_schema( Schema   :: json_term() | binary()
                           , Data     :: json_term() | binary()
                           , Options  :: [{Key :: atom(), Data :: any()}]


### PR DESCRIPTION
The _Data_ type specification for `validate/2` and `validate/3` is not the same.

For `validate/2` it's `json_term() | binary()` and for `validate/3` it's just `binary()`, which causes Dialyzer to go crazy when you pass in already parsed JSON.

This PR simply adds `json_term()` to the `validate/3` spec.
