### PR TITLE
missing_required_property and no_match return message fix

### DIFF
--- a/src/jesse_schema_validator.erl
+++ b/src/jesse_schema_validator.erl
@@ -429,7 +429,7 @@ check_properties(Value, Properties, State) ->
                              true ->
                                Error = { ?data_invalid
                                        , get_current_schema(CurrentState)
-                                       , ?missing_required_property
+                                       , {?missing_required_property, PropertyName}
                                        , Value
                                        },
                                handle_error(Error, CurrentState);
@@ -853,7 +853,7 @@ check_pattern(Value, Pattern, State) ->
     nomatch ->
       Error = { ?data_invalid
               , get_current_schema(State)
-              , ?no_match
+              , {?no_match, Pattern}
               , Value
               },
       handle_error(Error, State)


### PR DESCRIPTION
I noticed that both `missing_required_property` and `no_match` did not contain data based on `error_type()` from jesse.erl
