### PR TITLE
Add Erlang 17.0 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 %%-*- mode: erlang -*-
 
-{erl_opts, [ debug_info
+{erl_opts, [ {platform_define, "^[0-9]+", namespaced_dicts}
+           , debug_info
            , warnings_as_errors
            , warn_export_all
            ]}.

--- a/rebar.tests.config
+++ b/rebar.tests.config
@@ -4,4 +4,4 @@
 {deps, [ {jiffy,  ".*",  {git, "git://github.com/davisp/jiffy.git", {branch, "master"}}}
        ]}.
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
-{erl_opts, []}.
+{erl_opts, [{platform_define, "^[0-9]+", namespaced_dicts}]}.

--- a/src/jesse_json_path.erl
+++ b/src/jesse_json_path.erl
@@ -6,14 +6,22 @@
 -module(jesse_json_path).
 -export([path/2, value/3, to_proplist/1, unwrap_value/1]).
 
+-ifdef(namespaced_dicts).
+-type jesse_dict() :: dict:dict().
+-type jesse_gb_tree() :: gb_trees:tree().
+-else.
+-type jesse_dict() :: dict().
+-type jesse_gb_tree() :: gb_tree().
+-endif.
+
 -type elem_key_type() :: atom | binary | string | undefined.
 -type elem_type() :: list | elem_key_type().
 -type kvc_obj() :: kvc_obj_node() | [kvc_obj_node()] | list().
 -type kvc_key() :: binary() | atom() | string().
 -type proplist() :: [{kvc_key(), kvc_obj()}].
 -type kvc_obj_node() :: proplist() | {struct, proplist()}
-                      | dict() | gb_tree() | term().
--type typed_proplist() :: {proplist() | {gb_tree, gb_tree()}, elem_type()}.
+                      | jesse_dict() | jesse_gb_tree() | term().
+-type typed_proplist() :: {proplist() | {gb_tree, jesse_gb_tree()}, elem_type()}.
 
 -export_type([proplist/0, kvc_key/0, kvc_obj/0]).
 


### PR DESCRIPTION
This PR adds support for Erlang 17.0 without breaking all older versions.

`warnings_as_errors` was **not** turned off in order to achieve this. :smile:

I would have added 17.0 to `.travis.yml`, but Travis CI currently only supports 17.0-rc1.
