### PR TITLE
Fix validation for array with set of types (refs #31)

### DIFF
--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -280,8 +280,7 @@ check_union_type(Value, UnionType, State) ->
                      true  ->
                        %% case when there's a schema in the array,
                        %% then we need to validate against that schema
-                       NewState0 = jesse_state:set_allowed_errors(State, 0),
-                       NewState  = jesse_state:set_current_schema(NewState0, Type),
+                       NewState = jesse_state:new(Type, []),
                        _ = jesse_schema_validator:validate_with_state( Type
                                                                      , Value
                                                                      , NewState


### PR DESCRIPTION
This is a fix for #31 

Setting current_schema to the actual type being checked against fixes the 'no_extra_properties_allowed' issue mentioned. 

I'm still not happy about the actual error reporting because whatever you do, it would only report a "wrong_type". No matter if there are actual bad additional properties, missing properties or additional items.
